### PR TITLE
Add dockerfiles for juno

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ services:
 install:
   - docker build -t loki loki
   - docker build -t loki-unstable loki-unstable
+  - docker build -t juno-unstable juno-unstable
+  - docker build -t juno-devel juno-devel
 
 script:
   - echo BUILDS PASSED

--- a/juno-devel/Dockerfile
+++ b/juno-devel/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:bionic
+
+# Dependency for gpg --recv
+RUN apt-get update && apt-get install -y dirmngr
+
+# Adding through file instead of add-apt-repository saves the need for python3
+ADD elementary-ppa.list /etc/apt/sources.list.d/
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 6C8769CEDC20F5E66C3B7D37BF36996C4E1F8A59
+
+ENV containerVersion=210118
+ENV dependencies=""
+
+RUN apt-get update && \
+	apt-get install -y elementary-os-overlay \
+	 libglib2.0-dev \
+	 libgtk-3-dev \
+	 libgranite-dev \
+	 libwingpanel-2.0-dev \
+	 cmake \
+	 meson \
+	 valac \
+	 intltool && \
+	apt-get dist-upgrade -y && \
+	apt-get clean && \
+	rm -R /var/lib/apt/lists/* && \
+	mkdir /tmp/build-dir
+
+WORKDIR /tmp/build-dir
+
+ADD start.sh /start
+
+ENTRYPOINT ["/start"]

--- a/juno-devel/elementary-ppa.list
+++ b/juno-devel/elementary-ppa.list
@@ -1,0 +1,6 @@
+
+deb http://ppa.launchpad.net/elementary-os/daily/ubuntu bionic main
+deb-src http://ppa.launchpad.net/elementary-os/daily/ubuntu bionic main
+
+deb http://ppa.launchpad.net/elementary-os/os-patches/ubuntu bionic main
+deb-src http://ppa.launchpad.net/elementary-os/os-patches/ubuntu bionic main

--- a/juno-devel/start.sh
+++ b/juno-devel/start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+if [ -n "$dependencies" ]; then
+	apt-get update
+	apt-get install -y $dependencies
+fi
+
+# If no command is passed open bash
+if [ -z "$@" ]; then
+	exec "/bin/bash"
+else
+	exec "$@"
+fi

--- a/juno-unstable/Dockerfile
+++ b/juno-unstable/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:bionic
+
+# Dependency for gpg --recv
+RUN apt-get update && apt-get install -y dirmngr
+
+# Adding through file instead of add-apt-repository saves the need for python3
+ADD elementary-ppa.list /etc/apt/sources.list.d/
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 6C8769CEDC20F5E66C3B7D37BF36996C4E1F8A59
+
+ENV containerVersion=210118
+
+RUN apt-get update && \
+	apt-get install -y elementary-os-overlay && \
+	apt-get dist-upgrade -y && \
+	apt-get clean && \
+	rm -R /var/lib/apt/lists/*

--- a/juno-unstable/elementary-ppa.list
+++ b/juno-unstable/elementary-ppa.list
@@ -1,0 +1,6 @@
+
+deb http://ppa.launchpad.net/elementary-os/daily/ubuntu bionic main
+# deb-src http://ppa.launchpad.net/elementary-os/daily/ubuntu bionic main
+
+deb http://ppa.launchpad.net/elementary-os/os-patches/ubuntu bionic main
+# deb-src http://ppa.launchpad.net/elementary-os/os-patches/ubuntu bionic main

--- a/juno/Dockerfile
+++ b/juno/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:bionic
+
+# Dependency for gpg --recv
+RUN apt-get update && apt-get install -y dirmngr
+
+# Adding through file instead of add-apt-repository saves the need for python3
+ADD elementary-ppa.list /etc/apt/sources.list.d/
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 6C8769CEDC20F5E66C3B7D37BF36996C4E1F8A59
+
+ENV containerVersion=210118
+
+RUN apt-get update && \
+	apt-get install -y elementary-os-overlay && \
+	apt-get dist-upgrade -y && \
+	apt-get clean && \
+	rm -R /var/lib/apt/lists/*

--- a/juno/elementary-ppa.list
+++ b/juno/elementary-ppa.list
@@ -1,0 +1,6 @@
+
+deb http://ppa.launchpad.net/elementary-os/stable/ubuntu bionic main
+# deb-src http://ppa.launchpad.net/elementary-os/stable/ubuntu bionic main
+
+deb http://ppa.launchpad.net/elementary-os/os-patches/ubuntu bionic main
+# deb-src http://ppa.launchpad.net/elementary-os/os-patches/ubuntu bionic main


### PR DESCRIPTION
Obviously the stable image currently doesn't build as those repository don't exist yet. But the other two do.

I have added devel container is per issue #2. Currently using the daily repository. It installs just some base packages used by most travis builds. Additional dependencies can be added at runtime through an environment variable `dependencies`.

Most of the dockerfile contents are identical. I did think about setting up a base image but that ended up being more complicated then needed and create bigger images.