### PR TITLE
Push to existing docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,5 @@ jobs:
       run: |
         docker login -u "${{ secrets.DockerUsername }}" -p "${{ secrets.DockerPassword }}"
         cd "${{ matrix.image }}" || exit 1
-        docker build -t elementary/"${{ matrix.image }}" .
-        docker push elementary/"${{ matrix.image }}"
+        docker build -t elementary/docker:"${{ matrix.image }}" .
+        docker push elementary/docker:"${{ matrix.image }}"


### PR DESCRIPTION
Not sure how we missed it but the current CI creates/pushes 10 new docker images instead of 10 tags on the existing image.

The current `elementary/docker` image is very well used in other CIs so I believe that is the intended target.

Noticed it when I saw that the build succeeded but saw no activity on docker hub.

https://hub.docker.com/u/elementary