### PR TITLE
begin creating new images based off of the release name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,20 @@ jobs:
     - name: Build Docker Image
       run: |
         docker login -u "${{ secrets.DockerUsername }}" -p "${{ secrets.DockerPassword }}"
-        cd "${{ matrix.image }}" || exit 1
-        docker build -t elementary/docker:"${{ matrix.image }}" .
-        docker push elementary/docker:"${{ matrix.image }}"
+        IMAGE="${{ matrix.image }}"
+        IMAGE_NAME="$(echo "$IMAGE" | awk -F'-' '{print $1}')"
+        # cut the first hyphenated section from tag name, since it will be the image name instead
+        TAG=${IMAGE#*-}
+        cd "$IMAGE" || exit 1
+        # don't build default tags.
+        declare -a arr=("stable" "stable-installer" "unstable" "unstable-installer" "latest")
+        if [[ ! "${arr[@]}" =~ "$IMAGE" ]]; then
+          # rename unstable tags to latest
+          if [ "$TAG" == "unstable" ]; then TAG="latest"; fi
+          if [ "$TAG" == "unstable-installer" ]; then TAG="installer"; fi
+          docker build -t elementary/"$IMAGE_NAME":"$TAG" .
+          echo docker push elementary/"$IMAGE_NAME":"$TAG"
+        fi
+        # support older format for images and tags
+        docker build -t elementary/docker:"$IMAGE" .
+        docker push elementary/docker:"$IMAGE"


### PR DESCRIPTION
This should start dual building images in the older format (`elementary/docker:juno-stable` for example) as well as a new format:

`elementary/juno`
`elementary/juno:installer`
`elementary/juno:stable`
`elementary/juno:stable-installer`