### PR TITLE
Some cleanup following the best practices

### DIFF
--- a/juno-stable-installer/Dockerfile
+++ b/juno-stable-installer/Dockerfile
@@ -4,14 +4,15 @@ FROM ubuntu:bionic
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-	apt-get -y install software-properties-common && \
-	add-apt-repository -u -y ppa:elementary-os/os-patches && \
-	add-apt-repository -u -y ppa:elementary-os/stable && \
-	add-apt-repository -u -y ppa:system76/proposed && \
-	add-apt-repository -u -y ppa:system76/pop && \
-	apt-get install -y elementary-os-overlay && \
-	apt-get update && \
-	apt-get -y dist-upgrade && \
-  apt-get install --no-install-recommends -y elementary-sdk && \
-  apt-get -y autoremove && \
-  apt-get autoclean
+    apt-get -y install software-properties-common && \
+    add-apt-repository -u -y ppa:elementary-os/os-patches && \
+    add-apt-repository -u -y ppa:elementary-os/stable && \
+    add-apt-repository -u -y ppa:system76/proposed && \
+    add-apt-repository -u -y ppa:system76/pop && \
+    apt-get install -y elementary-os-overlay && \
+    apt-get update && \
+    apt-get -y dist-upgrade && \
+    apt-get install --no-install-recommends -y elementary-sdk && \
+    apt-get -y autoremove && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/*

--- a/juno-stable/Dockerfile
+++ b/juno-stable/Dockerfile
@@ -4,12 +4,13 @@ FROM ubuntu:bionic
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-	apt-get -y install software-properties-common && \
-	add-apt-repository -u -y ppa:elementary-os/os-patches && \
-	add-apt-repository -u -y ppa:elementary-os/stable && \
-	apt-get install -y elementary-os-overlay && \
-	apt-get update && \
-	apt-get -y dist-upgrade && \
-	apt-get install --no-install-recommends -y elementary-sdk && \
-  apt-get -y autoremove && \
-  apt-get autoclean
+    apt-get -y install software-properties-common && \
+    add-apt-repository -u -y ppa:elementary-os/os-patches && \
+    add-apt-repository -u -y ppa:elementary-os/stable && \
+    apt-get install -y elementary-os-overlay && \
+    apt-get update && \
+    apt-get -y dist-upgrade && \
+    apt-get install --no-install-recommends -y elementary-sdk && \
+    apt-get -y autoremove && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/*    

--- a/juno-unstable-installer/Dockerfile
+++ b/juno-unstable-installer/Dockerfile
@@ -4,14 +4,15 @@ FROM ubuntu:bionic
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-	apt-get -y install software-properties-common && \
-	add-apt-repository -u -y ppa:elementary-os/os-patches && \
-	add-apt-repository -u -y ppa:elementary-os/daily && \
-	add-apt-repository -u -y ppa:system76/proposed && \
-	add-apt-repository -u -y ppa:system76/pop && \
-	apt-get install -y elementary-os-overlay && \
-	apt-get update && \
-	apt-get -y dist-upgrade && \
-  apt-get install --no-install-recommends -y elementary-sdk && \
-  apt-get -y autoremove && \
-  apt-get autoclean
+    apt-get -y install software-properties-common && \
+    add-apt-repository -u -y ppa:elementary-os/os-patches && \
+    add-apt-repository -u -y ppa:elementary-os/daily && \
+    add-apt-repository -u -y ppa:system76/proposed && \
+    add-apt-repository -u -y ppa:system76/pop && \
+    apt-get install -y elementary-os-overlay && \
+    apt-get update && \
+    apt-get -y dist-upgrade && \
+    apt-get install --no-install-recommends -y elementary-sdk && \
+    apt-get -y autoremove && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/*

--- a/juno-unstable/Dockerfile
+++ b/juno-unstable/Dockerfile
@@ -4,12 +4,13 @@ FROM ubuntu:bionic
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-	apt-get -y install software-properties-common && \
-	add-apt-repository -u -y ppa:elementary-os/os-patches && \
-	add-apt-repository -u -y ppa:elementary-os/daily && \
-	apt-get install -y elementary-os-overlay && \
-	apt-get update && \
-	apt-get -y dist-upgrade && \
-  apt-get install --no-install-recommends -y elementary-sdk && \
-  apt-get -y autoremove && \
-  apt-get autoclean
+    apt-get -y install software-properties-common && \
+    add-apt-repository -u -y ppa:elementary-os/os-patches && \
+    add-apt-repository -u -y ppa:elementary-os/daily && \
+    apt-get install -y elementary-os-overlay && \
+    apt-get update && \
+    apt-get -y dist-upgrade && \
+    apt-get install --no-install-recommends -y elementary-sdk && \
+    apt-get -y autoremove && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/*

--- a/loki-stable/Dockerfile
+++ b/loki-stable/Dockerfile
@@ -4,11 +4,12 @@ FROM ubuntu:xenial
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-  apt-get -y install software-properties-common && \
-  add-apt-repository -u -y ppa:elementary-os/os-patches && \
-  add-apt-repository -u -y ppa:elementary-os/stable && \
-  apt-get install -y elementary-os-overlay && \
-  apt-get update && \
-  apt-get -y dist-upgrade && \
-  apt-get -y autoremove && \
-  apt-get autoclean
+    apt-get -y install software-properties-common && \
+    add-apt-repository -u -y ppa:elementary-os/os-patches && \
+    add-apt-repository -u -y ppa:elementary-os/stable && \
+    apt-get install -y elementary-os-overlay && \
+    apt-get update && \
+    apt-get -y dist-upgrade && \
+    apt-get -y autoremove && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/*

--- a/loki-unstable/Dockerfile
+++ b/loki-unstable/Dockerfile
@@ -4,11 +4,12 @@ FROM ubuntu:xenial
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-  apt-get -y install software-properties-common && \
-  add-apt-repository -u -y ppa:elementary-os/os-patches && \
-  add-apt-repository -u -y ppa:elementary-os/daily && \
-  apt-get install -y elementary-os-overlay && \
-  apt-get update && \
-  apt-get -y dist-upgrade && \
-  apt-get -y autoremove && \
-  apt-get autoclean
+    apt-get -y install software-properties-common && \
+    add-apt-repository -u -y ppa:elementary-os/os-patches && \
+    add-apt-repository -u -y ppa:elementary-os/daily && \
+    apt-get install -y elementary-os-overlay && \
+    apt-get update && \
+    apt-get -y dist-upgrade && \
+    apt-get -y autoremove && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/*

--- a/odin-unstable/Dockerfile
+++ b/odin-unstable/Dockerfile
@@ -4,12 +4,13 @@ FROM ubuntu:focal
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-	apt-get -y install software-properties-common && \
-	add-apt-repository -u -y ppa:elementary-os/os-patches && \
-	add-apt-repository -u -y ppa:elementary-os/daily && \
-	apt-get install -y elementary-os-overlay && \
-	apt-get update && \
-	apt-get -y dist-upgrade && \
-  apt-get install --no-install-recommends -y elementary-sdk && \
-  apt-get -y autoremove && \
-  apt-get autoclean
+    apt-get -y install software-properties-common && \
+    add-apt-repository -u -y ppa:elementary-os/os-patches && \
+    add-apt-repository -u -y ppa:elementary-os/daily && \
+    apt-get install -y elementary-os-overlay && \
+    apt-get update && \
+    apt-get -y dist-upgrade && \
+    apt-get install --no-install-recommends -y elementary-sdk && \
+    apt-get -y autoremove && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Some cleanup following the best practices:

https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run

> In addition, when you clean up the apt cache by removing /var/lib/apt/lists it reduces the image size, since the apt cache is not stored in a layer.