### PR TITLE
Odin stable update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         image: [
+          odin-stable,
           odin-unstable,
           juno-stable,
           juno-stable-installer,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         image:
+          - odin-stable
           - odin-unstable
           - juno-stable
           - juno-stable-installer

--- a/odin-stable/Dockerfile
+++ b/odin-stable/Dockerfile
@@ -1,0 +1,16 @@
+# elementary OS Odin STABLE
+FROM ubuntu:focal
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get -y install software-properties-common && \
+    add-apt-repository -u -y ppa:elementary-os/os-patches && \
+    add-apt-repository -u -y ppa:elementary-os/stable && \
+    apt-get install -y elementary-os-overlay && \
+    apt-get update && \
+    apt-get -y dist-upgrade && \
+    apt-get install --no-install-recommends -y elementary-sdk && \
+    apt-get -y autoremove && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/*

--- a/stable
+++ b/stable
@@ -1,1 +1,1 @@
-juno-stable
+odin-stable

--- a/stable-installer
+++ b/stable-installer
@@ -1,1 +1,1 @@
-juno-stable-installer/
+odin-stable


### PR DESCRIPTION
`stable` was still pointing to `juno`. We can probably remove these `-installer` containers too. It looks like the intention was to include the system76 PPA to get `distinst`, but that's in our PPA now. But I'm unsure if those containers are being used anywhere, and unsure of the best way to sunset them, so this will do for now.