### PR TITLE
Jammy: include gpg-agent

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           - juno-unstable-installer
           - loki-stable
           - loki-unstable
+          - next-unstable
           - stable
           - stable-installer
           - unstable

--- a/next-unstable/Dockerfile
+++ b/next-unstable/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:jammy
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-  apt-get -y install --no-install-recommends software-properties-common && \
+  apt-get -y install --no-install-recommends gpg-agent software-properties-common && \
   add-apt-repository -u -y ppa:elementary-os/os-patches && \
   add-apt-repository -u -y ppa:elementary-os/daily && \
   apt-get install -y --no-install-recommends elementary-os-overlay && \


### PR DESCRIPTION
https://github.com/elementary/docker/runs/4792891359?check_suite_focus=true
```
gpg: error running '/usr/bin/gpg-agent': probably not installed
716
gpg: failed to start agent '/usr/bin/gpg-agent': Configuration error
717
gpg: can't connect to the agent: Configuration error
```