### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
The GitHub Actions have dependencies so we should probably keep them updated.
The docker files **must not** be updated, or it will try and trigger builds of old OS's on new ubuntu bases.