### PR TITLE
publish: Don't fail fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         image: [
           development-target,


### PR DESCRIPTION
We don't want to fail the whole publish job if one of the containers fails to publish.