### PR TITLE
Add noble images and switch development-target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           stable,
           stable-installer,
           ubuntu-mantic-unstable,
+          ubuntu-noble-unstable,
           unstable,
           unstable-installer,
           latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
           - stable
           - stable-installer
           - ubuntu-mantic-unstable
+          - ubuntu-noble-unstable
           - unstable
           - unstable-installer
           - latest

--- a/development-target
+++ b/development-target
@@ -1,1 +1,1 @@
-ubuntu-mantic-unstable
+ubuntu-noble-unstable

--- a/ubuntu-noble-unstable/Dockerfile
+++ b/ubuntu-noble-unstable/Dockerfile
@@ -1,0 +1,16 @@
+# elementary OS UNSTABLE based on Ubuntu Noble
+FROM ubuntu:noble
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+  apt-get -y install --no-install-recommends gpg-agent software-properties-common git && \
+  add-apt-repository -u -y ppa:elementary-os/os-patches && \
+  add-apt-repository -u -y ppa:elementary-os/daily && \
+  apt-get install -y --no-install-recommends elementary-os-overlay && \
+  apt-get update && \
+  apt-get -y dist-upgrade && \
+  apt-get install --no-install-recommends -y elementary-sdk elementary-icon-theme && \
+  apt-get -y autoremove && \
+  apt-get autoclean && \
+  rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
There's now a Docker base image available for Ubuntu 24.04, so start building our `noble` images, and switch `development-target` to point to it.