### PR TITLE
Change 'next-unstable' tag target to 'circe-unstable'

### DIFF
--- a/next-unstable
+++ b/next-unstable
@@ -1,1 +1,1 @@
-horus-unstable/
+circe-unstable/


### PR DESCRIPTION
Updates next-unstable tag to circe-unstable and enable CI to build applications that depends on newer libraries and tools.